### PR TITLE
Allow to use the RootNode type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { BlocksRenderer } from './BlocksRenderer';
+import { BlocksRenderer, type RootNode } from './BlocksRenderer';
 
-export { BlocksRenderer };
+export { BlocksRenderer, RootNode };


### PR DESCRIPTION
If we display the RootNode type, it can be easily used into custom interfaces which are useful to define any API inputs.

### What does it do?

Just display the RootNode type in order to use it to define my API input type 👍 

```
import type { RootNode } from "@strapi/blocks-react-renderer";

export interface IStrapiAlertMessageData {
  title: string;
  message: RootNode[]; // <======= Here we go
  starting_date: string;
  ending_date: string;
}
```

### How to test it?

```
import type { IStrapiAlertMessageData } from "./AlertMessageComponent";

function AlertMessageDisplayBlock({ message }: IStrapiAlertMessageData) {
  return (
      <BlocksRenderer content={message} />
  );
}
```

### Please be kind

Hi, it is one my first PR of all time and English is not my first language so please apologize my lack of verbosity.
Hoping to be helpful.
