### PR TITLE
feat: export BlocksContent type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ npm install @strapi/blocks-react-renderer react react-dom
 After fetching your Strapi content, you can use the BlocksRenderer component to render the data from a blocks attribute. Pass the array of blocks coming from your Strapi API to the `content` prop:
 
 ```jsx
-import { BlocksRenderer } from '@strapi/blocks-react-renderer';
+import { BlocksRenderer, type BlocksContent } from '@strapi/blocks-react-renderer';
 
 // Content should come from your Strapi API
-const content = [
+const content: BlocksContent = [
   {
     type: 'paragraph',
     children: [{ type: 'text', text: 'A simple paragraph' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 import { BlocksRenderer } from './BlocksRenderer';
 
+import type { RootNode } from './BlocksRenderer';
+
+type BlocksContent = RootNode[];
+
 export { BlocksRenderer };
+export type { BlocksContent };


### PR DESCRIPTION
### What does it do?

- Exports a new BlocksContent type, which is an array of root nodes.
- Updates the readme to include that type

### Why is it needed?

For the convenience of users. For example if they have wrapped the renderer in a custom component like RichText, so they can define the prop types of that component.

### How to test it?

Import the `BlocksContent` type and use it

### Related issue(s)/PR(s)

The need for this was highlighted in #11