### PR TITLE
chore: bump version to 1.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/blocks-react-renderer",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "bugs": {
     "url": "https://github.com/strapi/blocks-react-renderer/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/blocks-react-renderer",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "bugs": {
     "url": "https://github.com/strapi/blocks-react-renderer/issues"
   },


### PR DESCRIPTION
### What does it do?

Upgrades the package.json version. The release was made to npm already

### Why is it needed?

To fix #14
