### PR TITLE
feat: parse code blocks children to plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ You can provide your own React components to the renderer, both for blocks and m
 
 - **Blocks** are full-width elements, usually at the root of the content. The available options are:
   - paragraph
-  - heading
-  - list
+  - heading (receives `level`)
+  - list (receives `format`)
   - quote
-  - code
-  - image
-  - link
+  - code (receives `plainText`)
+  - image (receives `image`)
+  - link (receives `url`)
 - **Modifiers** are inline elements, used to change the appearance of fragments of text within a block. The available options are:
   - bold
   - italic

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -22,11 +22,11 @@ const augmentProps = (content: Node) => {
     const getPlainText = (children: typeof childrenNodes): string => {
       return children.reduce((currentPlainText, node) => {
         if (node.type === 'text') {
-          return currentPlainText + node.text;
+          return currentPlainText.concat(node.text);
         }
 
         if (node.type === 'link') {
-          return currentPlainText + getPlainText(node.children);
+          return currentPlainText.concat(getPlainText(node.children));
         }
 
         return currentPlainText;

--- a/src/BlocksRenderer.tsx
+++ b/src/BlocksRenderer.tsx
@@ -85,7 +85,11 @@ type RootNode =
 type Node = RootNode | NonTextInlineNode;
 
 // Util to convert a node to the props of the corresponding React component
-type GetPropsFromNode<T> = Omit<T, 'type' | 'children'> & { children?: React.ReactNode };
+type GetPropsFromNode<T> = Omit<T, 'type' | 'children'> & {
+  children?: React.ReactNode;
+  // For code blocks, add a plainText property that is created by this renderer
+  plainText?: T extends { type: 'code' } ? string : never;
+};
 
 // Map of all block types to their matching React component
 type BlocksComponents = {
@@ -118,7 +122,7 @@ const defaultComponents: ComponentsContextValue = {
     quote: (props) => <blockquote>{props.children}</blockquote>,
     code: (props) => (
       <pre>
-        <code>{props.children}</code>
+        <code>{props.plainText}</code>
       </pre>
     ),
     heading: ({ level, children }) => {

--- a/tests/BlocksRenderer.test.tsx
+++ b/tests/BlocksRenderer.test.tsx
@@ -386,5 +386,37 @@ describe('BlocksRenderer', () => {
 
       console.warn = originalWarn;
     });
+
+    it('parses code blocks to plain text', () => {
+      render(
+        <BlocksRenderer
+          content={[
+            {
+              type: 'code',
+              children: [
+                {
+                  type: 'text',
+                  text: 'const a = 1;',
+                },
+                {
+                  type: 'link',
+                  url: 'https://test.com',
+                  children: [{ type: 'text', text: 'const b = 2;', bold: true }],
+                },
+              ],
+            },
+          ]}
+          blocks={{
+            code: (props) => (
+              <pre>
+                <code>{props.plainText}</code>
+              </pre>
+            ),
+          }}
+        />
+      );
+
+      expect(screen.getByText('const a = 1;const b = 2;')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
### What does it do?

It adds a `plainText` prop to the renderer component for code blocks.

### Why is it needed?

Like all other blocks, code blocks need to have an array of objects as children.

This makes it hard for users to implement syntax highlighting libraries that expect a plain text string. They need to parse the children to generate that string. This PR does this at the renderer level so they don't need to.

[See this discord message](https://discord.com/channels/811989166782021633/1175384598969065575/1176192679168708678)

### How to test it?

In a frontend app, use the renderer (link it via yarn), and pass a custom component for code that uses the `plainText` prop

