### PR TITLE
chore: add issue workflows

### DIFF
--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -1,0 +1,30 @@
+name: 'Daily Cron - 00:00'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  statuses: read
+
+jobs:
+  cron-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check for inactive issues that can't be reproduced
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'status: can not reproduce'
+          inactive-day: 14
+          close-reason: 'completed'
+          body: |
+            Hello!
+
+            As we have not received any new or updated information to reproduce this issue in the last 14 days we are marking this issue as closed. Should you have new information please feel free to respond and we will consider reopening it.
+
+            If anyone else have updated information for this issue, please open up a new bug report and simply reference this closed bug report so that we can get any new information you may have. If you have questions please refer to the [contributor's guide](https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md#reporting-an-issue) on opening issues.
+
+            Thank you and have a great day!

--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -1,0 +1,96 @@
+name: Issue Labeled
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  pull-requests: write
+  actions: read
+  checks: read
+  contents: read
+  repository-projects: read
+  statuses: read
+
+jobs:
+  issue-labeled:
+    runs-on: ubuntu-latest
+    steps:
+      # Unable to Reproduce Tasks
+      - name: 'Comment: unable to reproduce'
+        if: "${{ github.event.label.name == 'status: can not reproduce' }}"
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            > This is a templated message
+
+            Hello @${{ github.event.issue.user.login }},
+
+            Thank you for reporting this bug, however we are unable to reproduce the issue you described given the information we have on hand. Can you please create a fresh project that you are able to reproduce the issue in, provide clear steps to reproduce this issue, and either upload this fresh project to a new GitHub repo or compress it into a `.zip` and upload it on this issue?
+
+            We would greatly appreciate your assistance with this, by working in a fresh project it will cut out any possible variables that might be unrelated.
+            Please note that issues labeled with `status: can not reproduce` will be closed in 14 days if there is no activity.
+
+            Thank you!
+
+      # Invalid bug report template actions
+      - name: 'Comment: invalid bug report template'
+        if: "${{ github.event.label.name == 'flag: invalid template' }}"
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            > This is a templated message
+
+            Hello @${{ github.event.issue.user.login }},
+
+            We ask that you please follow the [issue template](https://raw.githubusercontent.com/strapi/strapi/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md).
+            A proper issue submission let's us better understand the origin of your bug and therefore help you. We will reopen your issue when we receive the issue following the template guidelines and properly fill out the template. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
+
+            Please update the issue with the template and we can reopen this report.
+
+            Thank you.
+      - name: 'Close: invalid bug report template'
+        if: "${{ github.event.label.name == 'flag: invalid template' }}"
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issue'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          close-reason: 'not_planned'
+
+      # Redirect questions to community sources
+      - name: 'Comment: redirect question to community'
+        if: "${{ github.event.label.name == 'flag: question' }}"
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            > This is a templated message
+
+            Hello @${{ github.event.issue.user.login }},
+
+            I see you are wanting to ask a question that is not really a bug report,
+
+            - questions should be directed to [our forum](https://forum.strapi.io) or our [Discord](https://discord.strapi.io)
+            - feature requests should be directed to our [feedback and feature request database](https://feedback.strapi.io)
+
+            Please see the following contributing guidelines for asking a question [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
+
+            Thank you.
+      - name: 'Close: redirect question to community'
+        if: "${{ github.event.label.name == 'flag: question' }}"
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issue'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          close-reason: 'complete'

--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -50,8 +50,8 @@ jobs:
 
             Hello @${{ github.event.issue.user.login }},
 
-            We ask that you please follow the [issue template](https://raw.githubusercontent.com/strapi/strapi/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md).
-            A proper issue submission let's us better understand the origin of your bug and therefore help you. We will reopen your issue when we receive the issue following the template guidelines and properly fill out the template. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
+            We ask that you please follow the [issue template](https://github.com/strapi/blocks-react-renderer/blob/main/.github/ISSUE_TEMPLATE/BUG_REPORT.yml).
+            A proper issue submission lets us better understand the origin of your bug and therefore help you. We will reopen your issue when we receive the issue following the template guidelines and properly fill out the template. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
 
             Please update the issue with the template and we can reopen this report.
 


### PR DESCRIPTION
### What does it do?

* adds issue workflows to handle some flags to help us manage issues (basically copied from `strapi/strapi`
