### PR TITLE
Fix: render empty paragraph as br elements

### DIFF
--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -65,6 +65,16 @@ const Block = ({ content }: BlockProps) => {
     return <BlockComponent {...props} />;
   }
 
+  // Handle empty paragraphs separately as they should render a <br> tag
+  if (
+    type === 'paragraph' &&
+    childrenNodes.length === 1 &&
+    childrenNodes[0].type === 'text' &&
+    childrenNodes[0].text === ''
+  ) {
+    return <br />;
+  }
+
   const augmentedProps = augmentProps(content);
 
   return (

--- a/tests/BlocksRenderer.test.tsx
+++ b/tests/BlocksRenderer.test.tsx
@@ -88,6 +88,33 @@ describe('BlocksRenderer', () => {
       expect(paragraph).toHaveTextContent('A paragraph with bold');
     });
 
+    it('renders a br when there is an empty paragraph', () => {
+      render(
+        <BlocksRenderer
+          content={[
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'First paragraph' }],
+            },
+            // empty paragraph
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: '' }],
+            },
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'Second paragraph' }],
+            },
+          ]}
+        />
+      );
+
+      // eslint-disable-next-line testing-library/no-node-access
+      const brElement = screen.getByText('First paragraph').nextElementSibling;
+      expect(brElement).toBeInTheDocument();
+      expect(brElement?.tagName).toBe('BR');
+    });
+
     it('renders quotes', () => {
       render(
         <BlocksRenderer


### PR DESCRIPTION
### What does it do?

It catches all the empty paragraphs and renders them as br elements

### Why is it needed?

With the previous implementation every time we had a new line was rendered as an empty paragraph

### How to test it?

In a frontend app, use the renderer (link it via yarn), and pass a content like this for example
`[
            {
              type: 'paragraph',
              children: [{ type: 'text', text: 'First paragraph' }],
            },
            // empty paragraph
            {
              type: 'paragraph',
              children: [{ type: 'text', text: '' }],
            },
            {
              type: 'paragraph',
              children: [{ type: 'text', text: 'Second paragraph' }],
            },
          ]`

### Related issue(s)/PR(s)

This PR solve this issue https://github.com/strapi/blocks-react-renderer/issues/12
