### PR TITLE
feat: add plainText to headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can provide your own React components to the renderer, both for blocks and m
 
 - **Blocks** are full-width elements, usually at the root of the content. The available options are:
   - paragraph
-  - heading (receives `level`)
+  - heading (receives `level` and `plainText`)
   - list (receives `format`)
   - quote
   - code (receives `plainText`)

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -16,30 +16,23 @@ const voidTypes = ['image'];
  */
 const augmentProps = (content: Node) => {
   const { children: childrenNodes, type, ...props } = content;
-  const getPlainText = (children: typeof childrenNodes): string => {
-    return children.reduce((currentPlainText, node) => {
-      if (node.type === 'text') {
-        return currentPlainText.concat(node.text);
-      }
 
-      if (node.type === 'link') {
-        return currentPlainText.concat(getPlainText(node.children));
-      }
-
-      return currentPlainText;
-    }, '');
-  };
-
-  if (type === 'code') {
+  if (type === 'code' || type === 'heading') {
     // Builds a plain text string from an array of nodes, regardless of links or modifiers
+    const getPlainText = (children: typeof childrenNodes): string => {
+      return children.reduce((currentPlainText, node) => {
+        if (node.type === 'text') {
+          return currentPlainText.concat(node.text);
+        }
 
-    return {
-      ...props,
-      plainText: getPlainText(content.children),
+        if (node.type === 'link') {
+          return currentPlainText.concat(getPlainText(node.children));
+        }
+
+        return currentPlainText;
+      }, '');
     };
-  }
 
-  if (type === 'heading') {
     return {
       ...props,
       plainText: getPlainText(content.children),

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -16,23 +16,30 @@ const voidTypes = ['image'];
  */
 const augmentProps = (content: Node) => {
   const { children: childrenNodes, type, ...props } = content;
+  const getPlainText = (children: typeof childrenNodes): string => {
+    return children.reduce((currentPlainText, node) => {
+      if (node.type === 'text') {
+        return currentPlainText.concat(node.text);
+      }
+
+      if (node.type === 'link') {
+        return currentPlainText.concat(getPlainText(node.children));
+      }
+
+      return currentPlainText;
+    }, '');
+  };
 
   if (type === 'code') {
     // Builds a plain text string from an array of nodes, regardless of links or modifiers
-    const getPlainText = (children: typeof childrenNodes): string => {
-      return children.reduce((currentPlainText, node) => {
-        if (node.type === 'text') {
-          return currentPlainText.concat(node.text);
-        }
 
-        if (node.type === 'link') {
-          return currentPlainText.concat(getPlainText(node.children));
-        }
-
-        return currentPlainText;
-      }, '');
+    return {
+      ...props,
+      plainText: getPlainText(content.children),
     };
+  }
 
+  if (type === 'heading') {
     return {
       ...props,
       plainText: getPlainText(content.children),

--- a/src/BlocksRenderer.tsx
+++ b/src/BlocksRenderer.tsx
@@ -88,7 +88,7 @@ type Node = RootNode | NonTextInlineNode;
 type GetPropsFromNode<T> = Omit<T, 'type' | 'children'> & {
   children?: React.ReactNode;
   // For code blocks, add a plainText property that is created by this renderer
-  plainText?: T extends { type: 'code' } ? string : never;
+  plainText?: T extends { type: 'code' | 'heading' } ? string : never;
 };
 
 // Map of all block types to their matching React component

--- a/tests/BlocksRenderer.test.tsx
+++ b/tests/BlocksRenderer.test.tsx
@@ -445,5 +445,27 @@ describe('BlocksRenderer', () => {
 
       expect(screen.getByText('const a = 1;const b = 2;')).toBeInTheDocument();
     });
+
+    it('parses headings to plain text', () => {
+      render(
+        <BlocksRenderer
+          content={content}
+          blocks={{
+            heading: (props) => {
+              const HeadingLevel = `h${props.level}` as keyof React.JSX.IntrinsicElements;
+              return (
+                <HeadingLevel data-testid="heading-with-id" data-plain-text={props.plainText}>
+                  {props.children}
+                </HeadingLevel>
+              );
+            },
+          }}
+        />
+      );
+
+      const element = screen.getByTestId('heading-with-id');
+
+      expect(element.dataset.plainText).toBe('A cool website');
+    });
   });
 });


### PR DESCRIPTION
### What does it do?

It allows to have access to the plainText of a heading block.

### Why is it needed?

Sometimes you might want to have access to the plain text of a heading to be able to add an attribute to it, like for creating anchors to point to them.

### How to test it?

In a frontend app, use the renderer (link it via yarn), and pass a custom component for `heading` that uses the plainText prop

### Related issue(s)/PR(s)

Inspired by https://github.com/strapi/blocks-react-renderer/pull/17
