### PR TITLE
change package.json "type" for module Resolving issue #49 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "url": "https://strapi.io"
     }
   ],
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
### What does it do?

Change in the package.json 'type' commonjs for module

### Why is it needed?

Resolve issue #49 for correction the bug 

### How to test it?

install the package @strapi/blocks-react-render and run the project whit nextjs, import the compoenet BlocksRenderer and using

### Related issue(s)/PR(s)

Resolving issue #49 
