### PR TITLE
Added language string property to CodeBlockNode interface

### DIFF
--- a/src/BlocksRenderer.tsx
+++ b/src/BlocksRenderer.tsx
@@ -37,6 +37,7 @@ interface QuoteBlockNode {
 interface CodeBlockNode {
   type: 'code';
   children: DefaultInlineNode[];
+  language: string;
 }
 
 interface HeadingBlockNode {


### PR DESCRIPTION
### What does it do?
This PR adds a new language property to the CodeBlockNode interface. This field is of type string and specifies the programming language of the code block, enabling support for syntax highlighting and better parsing.

### Why is it needed?
Previously, CodeBlockNode only included type and children, which made it impossible to identify the language of a code block. This enhancement is necessary to correctly render and process code blocks with language-specific formatting. Without this property, rendering engines or transformers might fail or default to plain text, leading to suboptimal UX.

### How to test it?
Update the schema or types in your dev environment.

Add a CodeBlockNode with a language field (e.g., language: "javascript").

Ensure that any logic relying on the CodeBlockNode type (renderers, serializers, deserializers) now reads and uses the language field correctly.

Verify that type-checking fails if the language field is missing when required.

### Related issue(s)/PR(s)
N/A (add a link here if this PR is related to a specific GitHub issue or another PR)